### PR TITLE
Add a NetNS (network namespace) parameter to the CreateVM request

### DIFF
--- a/proto/firecracker.proto
+++ b/proto/firecracker.proto
@@ -41,6 +41,9 @@ message CreateVMRequest {
     string MetricsFifoPath = 13;
 
     FirecrackerBalloonDevice BalloonDevice = 14;
+
+    // The network namespace of the VM.
+    string NetNS = 15;
 }
 
 message CreateVMResponse {

--- a/runtime/service.go
+++ b/runtime/service.go
@@ -974,6 +974,8 @@ func (s *service) buildVMConfiguration(req *proto.CreateVMRequest) (*firecracker
 
 	if req.JailerConfig != nil {
 		cfg.NetNS = req.JailerConfig.NetNS
+	} else {
+		cfg.NetNS = req.NetNS
 	}
 
 	s.logger.Debugf("using socket path: %s", cfg.SocketPath)


### PR DESCRIPTION
The current NetNS (network namespace) parameter nested in the JailerConfig
parameter requires specifying the entire jailer configuration, which is not
convenient. It is also not compatible with using a noop jailer.

To overcome this limitation, add a new NetNS parameter to the CreateVM
request.
